### PR TITLE
Fixes for Pcell evaluation errors and other warnings

### DIFF
--- a/cdsgit-binder/Binder.ils
+++ b/cdsgit-binder/Binder.ils
@@ -35,7 +35,7 @@ let(
 )
 
 ;Add Bindkeys
-defmethod( Add (( b Binder) bkList)
+defmethod( AddCG (( b Binder) bkList)
    bkLength = length(car(bkList))
    if( b->verbose printf("bkList length %L\n" bkLength) )
 

--- a/cdsgit-binder/binder_test.ils
+++ b/cdsgit-binder/binder_test.ils
@@ -16,7 +16,7 @@ myBindkeys = list(
 
 bk = Binder(?verbose t)
 
-Add(bk myBindkeys)
+AddCG(bk myBindkeys)
 
 
 

--- a/cdsgit-build/cdsgit.il
+++ b/cdsgit-build/cdsgit.il
@@ -1673,7 +1673,7 @@ defmethod( GetAll (( ge GitEnv ) settingsPath)
 
    if( ge->verbose printf("GitEnv GetAll: Getting all variables from %s\n" settingsPath) )
 
-   envString = Open(ge settingsPath)
+   envString = OpenCG(ge settingsPath)
 
    ge->varList = Parse(ge envString)
 
@@ -1693,19 +1693,19 @@ defmethod( Get (( ge GitEnv ) varName @key (forcedPath nil))
    if(forcedPath then
       if( ge->verbose printf(strcat("GitEnv Git: Getting variable " varName " from forcedPath " forcedPath "\n")))
       envList = GetAll(ge forcedPath)
-      envVar = Search(ge varName)
+      envVar = SearchCG(ge varName)
    else
 
       
       if( ge->verbose printf(strcat("GitEnv Git: Getting variable " varName " from " ge->user_path "\n")))
       envList = GetAll(ge ge->user_path)
-      varValue = Search(ge varName)
+      varValue = SearchCG(ge varName)
 
       
       if( !varValue then
          if( ge->verbose printf(strcat("GitEnv Git: Getting variable " varName " from " ge->global_path "\n")))
          envList = GetAll(ge ge->global_path)
-         envVar = Search(ge varName)
+         envVar = SearchCG(ge varName)
       )
    )
 
@@ -1869,7 +1869,7 @@ defmethod( Set (( ge GitEnv ) setName setValue )
 
    foutString = ""
 
-   envString = Open(ge ge->user_path)
+   envString = OpenCG(ge ge->user_path)
    strList = parseString(envString "\n")
 
    writeFile = nil
@@ -2207,7 +2207,7 @@ procedure( CGmergeAbortCB(gs)
    response = Dialog(gs "Aborting Merge will cause all uncommitted changes to be lost!!\nProceed?")
 
    if( response then
-      Merge(gs "--abort")
+      MergeCG(gs "--abort")
    )
 
 )
@@ -3421,7 +3421,7 @@ procedure( CGBSmergeFormCB()
    if(rf_branches_value then
       src_branch = nthelem(1 rf_branches_value)
       if( gs->verbose printf("CGBSmergeFormCB: Attempting to merge %L",src_branch))
-      result = Merge(gs src_branch)
+      result = MergeCG(gs src_branch)
       if( result == "warning" then
          response = Dialog(gs "Merge failed due to conflicts\nOpen the Merge confilt resolve form?")
          if(response then

--- a/cdsgit-build/cdsgit.il
+++ b/cdsgit-build/cdsgit.il
@@ -323,10 +323,10 @@ procedure( GSstr(str)
 )
 
 
-defmethod( Reverse (( gss GSstr))
+defmethod( ReverseCG (( gss GSstr))
 
    resultStr=""
-   len = Length(gss)
+   len = LengthCG(gss)
 
    for(i 1 len
       resultStr = strcat(resultStr GetChar(gss len-(i-1)) )
@@ -337,7 +337,7 @@ defmethod( Reverse (( gss GSstr))
 )
 
 
-defmethod( Length (( gss GSstr))
+defmethod( LengthCG (( gss GSstr))
    len = strlen(gss->str)
    gss->length = len
    len
@@ -357,7 +357,7 @@ defmethod( GetChar (( gss GSstr) index @key (str nil) )
 )
 
 
-defmethod( Strip (( gss GSstr ) @key (str_begin t) (str_end t) (rexStr " \t\n") )
+defmethod( StripCG (( gss GSstr ) @key (str_begin t) (str_end t) (rexStr " \t\n") )
 
    str = gss->str
 
@@ -402,14 +402,14 @@ procedure( GSpath(str @key (indexStatus nil) (treeStatus nil) (gs nil) )
       ?gs gs
    )
 
-   Type(newGsp)
+   TypeCG(newGsp)
 
    newGsp
 
 )
 
 
-defmethod( Clone ((gsp GSpath) @key (str gsp->str) )
+defmethod( CloneCG ((gsp GSpath) @key (str gsp->str) )
 
    gsp_clone = GSpath( str
       ?indexStatus gsp->indexStatus
@@ -423,7 +423,7 @@ defmethod( Clone ((gsp GSpath) @key (str gsp->str) )
    gsp_clone->verbose   = gsp->verbose
    gsp_clone->depth     = gsp->depth
 
-   Type(gsp_clone)
+   TypeCG(gsp_clone)
 
    gsp_clone
 )
@@ -437,13 +437,13 @@ defmethod( Trim (( gsp GSpath ) @key (loop 1) (reverse t))
    
    
 
-   if(reverse Reverse(gsp) )
+   if(reverse ReverseCG(gsp) )
 
    for(i 1 loop
       resultStr = trimHelper(gsp)
    )
 
-   if(reverse Reverse(gsp) )
+   if(reverse ReverseCG(gsp) )
 
    gsp->str
 )
@@ -459,7 +459,7 @@ procedure( trimHelper(gsp)
 
    resultStr = ""
 
-   len = Length(gsp)
+   len = LengthCG(gsp)
 
    found = nil
 
@@ -489,7 +489,7 @@ defmethod( Depth (( gsp GSpath))
    depth = 0
    clast = ""
 
-   len = Length(gsp)
+   len = LengthCG(gsp)
 
    for( cindex 1 len
       c = GetChar(gsp cindex)
@@ -563,8 +563,8 @@ let( (i)
 
    if(gsp->verbose printf("String Convolve\n\tstrL-%s\n\tstrR-%s\n" strL->str strR->str) )
 
-   lenL = Length(strL)
-   lenR = Length(strR)
+   lenL = LengthCG(strL)
+   lenR = LengthCG(strR)
 
 
    
@@ -628,7 +628,7 @@ defmethod( Subtract (( gsp GSpath ) gspS )
 if( GetChar(gsp 1)!="/" || GetChar(ogsp 1) !="/" then
    error("GSpath Subtract: Paths not be relative\nPath-%s OtherPath-%s" gsp->str gspS->str)
 )
-if( Length(gsp) < Length(gspS) then 
+if( LengthCG(gsp) < LengthCG(gspS) then
    error("GSpath Subtract: Paths not be relative\nPath-%s OtherPath-%s" gsp->str gspS->str)
 )
 
@@ -636,8 +636,8 @@ if( !IsInPath(gsp gspS)
       error("GSpath Subtract: One path must be a subdirectory of the other\nPath-%s OtherPath-%s" gsp->str gspS->str)
 )
 
-if(  Length(gsp) > Length(gspS) then
-   tmpStr = substring( gsp->str Length(gspS)+1 )
+if(  LengthCG(gsp) > LengthCG(gspS) then
+   tmpStr = substring( gsp->str LengthCG(gspS)+1 )
 else
    tmpStr = ""
 )
@@ -647,7 +647,7 @@ resultPath
 
 )
 
-defmethod( Type ((gsp GSpath))
+defmethod( TypeCG ((gsp GSpath))
 
       gsp->isDir  = isDir(gsp->str)
       gsp->isFile = isFile(gsp->str)
@@ -679,12 +679,12 @@ if( GetChar(gsp 1)!="/" || GetChar(ogsp 1) !="/" then
 )
 
 matched = nil
-if( Length(gsp) < Length(ogsp) then 
+if( LengthCG(gsp) < LengthCG(ogsp) then
    matched = nil
 else
 
    matched = t
-   for(i 1 Length(ogsp)
+   for(i 1 LengthCG(ogsp)
 
       cho = GetChar(ogsp i)
       chi = GetChar(gsp i)
@@ -711,7 +711,7 @@ defmethod( FullPath ((  gsp GSpath  ))
    )
 
    fullStr = strcat(gsp->gs->root->str "/" gsp->str)
-   fullGsp = Clone(gsp ?str fullStr)
+   fullGsp = CloneCG(gsp ?str fullStr)
    fullGsp
 )
 
@@ -751,7 +751,7 @@ defmethod( GetLib (( gsp GSpath ) )
 
 
 
-defmethod( Error (( gs GitShell ) errStr)
+defmethod( ErrorCG (( gs GitShell ) errStr)
 
 
    hiDisplayAppDBox(?name 'gitShellErrorForm
@@ -816,7 +816,7 @@ defmethod( Depth (( gs GitShell ))
             gs->ideal_filter = 1
          )
          (t
-            Error(gs "Depth(gs) failed: dd->type is unknown!")
+            ErrorCG(gs "Depth(gs) failed: dd->type is unknown!")
          )
       )
    else
@@ -877,7 +877,7 @@ defmethod( SetRoot (( gs GitShell ))
 defmethod( Check (( gs GitShell ))
 
    if( !isDir(gs->path) && gs->path != ""
-      Error(gs sprintf(nil "GitShell Check -- %L not a directory.\nSupport for files needs to be added" gs->path) )
+      ErrorCG(gs sprintf(nil "GitShell Check -- %L not a directory.\nSupport for files needs to be added" gs->path) )
    )
 
    syscmd = strcat("cd " gs->path " && git rev-parse --is-inside-work-tree ")
@@ -886,7 +886,7 @@ defmethod( Check (( gs GitShell ))
 
    if(result!="true\n" then
       gs->valid = nil
-      if( !gs->silent Error(gs sprintf(nil "Not a valid Git repository %s" gs->path)) )
+      if( !gs->silent ErrorCG(gs sprintf(nil "Not a valid Git repository %s" gs->path)) )
    else
       gs->valid = t
    )
@@ -932,7 +932,7 @@ defmethod( Cmd (( gs GitShell ) sysCommand @key (ignoreFatal nil))
          responseParse = parseString(response "\n")
 
          if( pcreMatchp( "^fatal" car(responseParse)) || pcreMatchp( "^error" car(responseParse))  then
-            Error(gs sprintf(nil "Git command returned fatal:\n%s" response))
+            ErrorCG(gs sprintf(nil "Git command returned fatal:\n%s" response))
          )
       )
    )
@@ -967,7 +967,7 @@ let( (path)
    path = gs->path
 
    if( !branchname then
-      Error(gs "GitShell Log: branchname cannot be nil")
+      ErrorCG(gs "GitShell Log: branchname cannot be nil")
    )
 
    if(gs->verbose printf("LCBUgitRevs: Reading git log\n"))
@@ -977,7 +977,7 @@ let( (path)
    response = Cmd(gs gitLogCmd)
 
    if( response=="" || !response
-      Error(gs sprintf(nil "Path %s has an empty git log\nDo revisions of it exist in the repository?" gs->path))
+      ErrorCG(gs sprintf(nil "Path %s has an empty git log\nDo revisions of it exist in the repository?" gs->path))
    )
 
    lineList = parseString(response "\n")
@@ -995,7 +995,7 @@ let( (path)
 
             
             if(logCount > 0 then
-               gitLog = Strip(GSstr(gitLog))
+               gitLog = StripCG(GSstr(gitLog))
                revList = cons(list(gitCommit gitAuthor gitDate gitLog) revList)
             )
 
@@ -1090,7 +1090,7 @@ defmethod( Status (( gs GitShell ) @key (showInfo t) )
    response = Cmd(gs status_cmd)
 
    if(!response then
-      Error(gs sprintf(nil "git status on path %s failed" gs->path))
+      ErrorCG(gs sprintf(nil "git status on path %s failed" gs->path))
    )
 
    if(response=="" then
@@ -1148,7 +1148,7 @@ let( (path)
    foreach( gsp gs->paths
 
       
-      gsp_tmp = Clone(gsp)
+      gsp_tmp = CloneCG(gsp)
 
       trim_depth  = gs->filter - (3 - gsp_tmp->pathDepth)
 
@@ -1224,10 +1224,10 @@ defmethod( Root (( gs GitShell ))
    result=Cmd(gs syscmd)
 
    if(!result then
-      Error(gs sprintf(nil "Not a valid path %s\nCommand:%s" oppath syscmd))
+      ErrorCG(gs sprintf(nil "Not a valid path %s\nCommand:%s" oppath syscmd))
    else
       gss_result=GSpath(result)
-      Strip(gss_result)
+      StripCG(gss_result)
       gs->root = gss_result
    )
 
@@ -1258,7 +1258,7 @@ defmethod( Commit (( gs GitShell ) commit_log @key (merge nil) )
          result=Cmd(gs syscmd)
 
          if(!result then
-            Error(gs sprintf(nil "Not a valid path %s\nCommand:%s" gs->path syscmd))
+            ErrorCG(gs sprintf(nil "Not a valid path %s\nCommand:%s" gs->path syscmd))
          )
       )
    else
@@ -1278,19 +1278,19 @@ defmethod( CloneRepo (( gs GitShell ))
          result=Cmd(gs syscmd)
 
          if(!result then
-            Error(gs sprintf(nil "Not a valid url %s\nCommand:%s" gs->url syscmd))
+            ErrorCG(gs sprintf(nil "Not a valid url %s\nCommand:%s" gs->url syscmd))
          else
 
             badresult = car( parseString(result) ) == "fatal:"
 
             if(badresult then
-               Error(gs sprintf(nil "Clone Failed!\n URL\n  %s\nDestination\n  %s\nResponse\n  %s" gs->url gs->path response) )
+               ErrorCG(gs sprintf(nil "Clone Failed!\n URL\n  %s\nDestination\n  %s\nResponse\n  %s" gs->url gs->path response) )
             )
 
             Info(gs sprintf(nil "Clone Success!\n URL\n  %s\nDestination\n  %s" gs->url gs->path) )
          )
       else
-         Error(gs sprintf(nil "Please enter a URL to clone!\n %L" gs->url) )
+         ErrorCG(gs sprintf(nil "Please enter a URL to clone!\n %L" gs->url) )
       )
    )
 
@@ -1321,7 +1321,7 @@ defmethod( Branch (( gs GitShell ) @key (args "") (showCurrent t) )
    result=Cmd(gs syscmd)
 
    if(!result then
-      Error(gs sprintf(nil "Not a valid path %s\nCommand:%s" gs->root->str syscmd))
+      ErrorCG(gs sprintf(nil "Not a valid path %s\nCommand:%s" gs->root->str syscmd))
    else
 
       foreach(line parseString(result "\n")
@@ -1361,7 +1361,7 @@ defmethod( Merge (( gs GitShell ) merge_args)
       result=Cmd(gs syscmd)
 
       if(!result then
-         Error(gs sprintf(nil "Merge failed\nCommand:%s" syscmd))
+         ErrorCG(gs sprintf(nil "Merge failed\nCommand:%s" syscmd))
       )
    )
 
@@ -1373,7 +1373,7 @@ defmethod( Merge (( gs GitShell ) merge_args)
       cond(
          (rexMatchp("^warning" first_line) result = "warning")
          (rexMatchp("^error" first_line)
-            Error(gs sprintf(nil "Cannot Merge. Do you have modified files in your work tree?\n\n'git merge' returned:\n%s" result))
+            ErrorCG(gs sprintf(nil "Cannot Merge. Do you have modified files in your work tree?\n\n'git merge' returned:\n%s" result))
          )
          (t result = t)
       )
@@ -1396,7 +1396,7 @@ defmethod( Export (( gs GitShell ) gitSHA)
 
    else
 
-      Error(gs "Must select a valid SHA")
+      ErrorCG(gs "Must select a valid SHA")
 
    )
 
@@ -1415,7 +1415,7 @@ defmethod( Checkout (( gs GitShell ) gitSHA @key (oppath ".") (args nil) )
       if( gitSHA && gitSHA !="" then
          Cmd(gs strcat("cd " gs->path " && git checkout " gitSHA " -- " oppath) )
       else
-         Error(gs "GitShell Checkout: Must select a valid SHA")
+         ErrorCG(gs "GitShell Checkout: Must select a valid SHA")
       )
    )
 
@@ -1429,7 +1429,7 @@ defmethod( CheckFormat (( gs GitShell ) refname)
       response = Cmd(gs strcat("git check-ref-format --branch \"" refname "\"") )
 
    else
-      Error(gs "GitShell CheckFormat: refname must be a string")
+      ErrorCG(gs "GitShell CheckFormat: refname must be a string")
    )
    response
 
@@ -1443,7 +1443,7 @@ defmethod( Init (( gs GitShell ) @key (args "") )
 
    if( !gs->path || !isDir(gs->path) then
       break()
-      Error(gs sprintf(nil "GitShell Init: %L is not a directory" gs->path) )
+      ErrorCG(gs sprintf(nil "GitShell Init: %L is not a directory" gs->path) )
    )
 
    syscmd = strcat("cd " gs->path " && git init " args)
@@ -1459,7 +1459,7 @@ defmethod( Push (( gs GitShell ) @key (remote "origin") (args ""))
    result=Cmd(gs syscmd)
 
    if(!result then
-      Error(gs sprintf(nil "Push failed\nCommand:%s\nResponse%s" syscmd result))
+      ErrorCG(gs sprintf(nil "Push failed\nCommand:%s\nResponse%s" syscmd result))
    else
       Info(gs result)
    )
@@ -1475,7 +1475,7 @@ defmethod( Pull (( gs GitShell ) @key (remote "origin") (args ""))
    result=Cmd(gs syscmd)
 
    if(!result then
-      Error(gs sprintf(nil "Pull failed\nCommand:%s\nResponse%s" syscmd result))
+      ErrorCG(gs sprintf(nil "Pull failed\nCommand:%s\nResponse%s" syscmd result))
    else
       Info(gs result)
    )
@@ -1488,7 +1488,7 @@ defmethod( Fetch (( gs GitShell ) @key (remote "origin") (args ""))
    result=Cmd(gs syscmd)
 
    if(!result then
-      Error(gs sprintf(nil "Fetch failed\nCommand:%s\nResponse%s" syscmd result))
+      ErrorCG(gs sprintf(nil "Fetch failed\nCommand:%s\nResponse%s" syscmd result))
    else
       if( result == "" then
          Info(gs "Fetch Complete (nothing to fetch)")
@@ -1507,19 +1507,19 @@ defmethod( Reset (( gs GitShell ) oppath)
       result=Cmd(gs syscmd)
 
       if(!reset then
-         Error(gs sprintf(nil "Not a valid path %s\nCommand:%s" oppath syscmd))
+         ErrorCG(gs sprintf(nil "Not a valid path %s\nCommand:%s" oppath syscmd))
       )
    )
    t
 )
-defmethod( Add (( gs GitShell ) oppath)
+defmethod( AddCG (( gs GitShell ) oppath)
 
    if( oppath && oppath != "" then
       syscmd = strcat("cd " gs->root->str " && git add --all -- " oppath)
       result=Cmd(gs syscmd)
 
       if(!result then
-         Error(gs sprintf(nil "Not a valid path %s\nCommand:%s" oppath syscmd))
+         ErrorCG(gs sprintf(nil "Not a valid path %s\nCommand:%s" oppath syscmd))
       )
    )
 
@@ -1627,8 +1627,8 @@ defmethod( Check (( ge GitEnv ))
    
    foreach( envVar envVars
 
-      defaultValue = Get(ge envVar ?forcedPath ge->global_path)
-      setValue     = Get(ge envVar)
+      defaultValue = GetCG(ge envVar ?forcedPath ge->global_path)
+      setValue     = GetCG(ge envVar)
 
       if( defaultValue != setValue then
          mismatchString = strcat( mismatchString "\n" envVar " " setValue)
@@ -1684,7 +1684,7 @@ defmethod( GetAll (( ge GitEnv ) settingsPath)
 
 
 
-defmethod( Get (( ge GitEnv ) varName @key (forcedPath nil))
+defmethod( GetCG (( ge GitEnv ) varName @key (forcedPath nil))
 
    if( ge->verbose printf("========GitEnv Git============\n"))
 
@@ -1841,13 +1841,13 @@ defmethod( Search (( ge GitEnv ) varName )
    returnVar
 
 )
-defmethod( Set (( ge GitEnv ) setName setValue )
+defmethod( SetCG (( ge GitEnv ) setName setValue )
 
    if( ge->verbose printf("========GitEnv Set============\n"))
 
    printf(strcat("GitEnv Set: Setting variable " setName " to " setValue " in " ge->user_path "\n"))
 
-   globalValue = Get(ge setName ?forcedPath ge->global_path)
+   globalValue = GetCG(ge setName ?forcedPath ge->global_path)
 
    
    line =  strcat(setName " = " setValue)
@@ -1936,7 +1936,7 @@ defmethod( SetShell (( ge GitEnv ) varName @key (override t) )
    if( !shellResponse || override then
 
       if( ge->verbose printf(strcat("GitEnv SetShell: Setting Shell variable " varName " to " varName "\n")))
-      varValue = Get(ge varName)
+      varValue = GetCG(ge varName)
       setShellEnvVar(strcat(varName "=" varValue))
 
       shellResponse = getShellEnvVar(varName)
@@ -2116,7 +2116,7 @@ procedure( CGMlmgrCB(_menuName lib _c _v _f _cat)
       ("CGMcommit"        CGstatusForm(gs)   )
       ("CGMexport"        CGexportForm(gs)   )
       ("CGMcheckout"      CGcheckoutForm(gs) )
-      ("CGMadd"           Add(gs gs->path)   )
+      ("CGMadd"           AddCG(gs gs->path)   )
       ("CGMreset"         Reset(gs gs->path) )
       ("CGMdiscard"       Discard(gs)        )
       
@@ -2132,7 +2132,7 @@ procedure( CGMlmgrCB(_menuName lib _c _v _f _cat)
       ("CGMrePull"        CGremoteCB(gs "pull")  )
       ("CGMreFetch"       CGremoteCB(gs "fetch") )
       
-      (t              Error( GitShell(?path "") strcat("Function " _menuName " has not been implemented yet!")  ) )
+      (t              ErrorCG( GitShell(?path "") strcat("Function " _menuName " has not been implemented yet!")  ) )
 
    )
 
@@ -2684,7 +2684,7 @@ procedure( CGstatusFormToggleCB()
          oppath = nthelem(3 fchoice)
 
          case(operation
-            ("add"     Add(gs oppath ) )
+            ("add"     AddCG(gs oppath ) )
             ("reset" Reset(gs oppath ) )
             (t error("invalied Toggle operation"))
          )
@@ -2937,7 +2937,7 @@ procedure( CGmergeResolveFormAddCB(option)
       oppath = nthelem(3 fchoice)
 
       Checkout(gs strcat("--" option) ?oppath oppath)
-      Add(gs oppath)
+      AddCG(gs oppath)
 
       case( option
          ("ours"   cgmergeresolve_form->rf_ours   = CGappendRFchoices(cgmergeresolve_form->rf_ours   fchoice) )
@@ -3228,7 +3228,7 @@ procedure( CGexportFormCB()
    revSelected = CGgetRFchoices(cgrevselect_form->rf_revs)
 
    if( !gs->valid then
-      Error(gs "Object is not in a valid git repository")
+      ErrorCG(gs "Object is not in a valid git repository")
    )
 
    if(revSelected then
@@ -3268,7 +3268,7 @@ procedure( CGcheckoutForm(gs)
 
    Status(gs ?showInfo nil)
    if( !gs->clean then
-      Error(gs "Cannot Checkout, you have uncommited modifications\n")
+      ErrorCG(gs "Cannot Checkout, you have uncommited modifications\n")
    )
 
    CGrevSelectForm(gs ?formTitle formTitle ?formCB formCB)
@@ -3283,7 +3283,7 @@ procedure( CGcheckoutFormCB()
    gs = cgrevselect_form->gs
 
    if( !gs->valid then
-      Error(gs "Object is not in a valid git repository")
+      ErrorCG(gs "Object is not in a valid git repository")
    )
 
    if(revSelected then
@@ -3292,7 +3292,7 @@ procedure( CGcheckoutFormCB()
 
       Status(gs ?showInfo nil)
       if( !gs->clean then
-         Error(gs "Cannot Checkout, you have uncommited modifications\n")
+         ErrorCG(gs "Cannot Checkout, you have uncommited modifications\n")
       else
          Checkout(gs gitSHA)
          Reset(gs gs->path)
@@ -3428,7 +3428,7 @@ procedure( CGBSmergeFormCB()
             gs->path = gs->root->str
             CGmergeResolveForm(gs)
          else
-            Error(gs "Merge failed due to unresolved conflicts")
+            ErrorCG(gs "Merge failed due to unresolved conflicts")
          )
       )
    )
@@ -3506,7 +3506,7 @@ procedure( CGBSbranchopCB(branchop)
    parent_branch = nthelem(1 rf_branches_value)
 
    if( !rf_branches_value then
-      Error(gs "You must select a Branch")
+      ErrorCG(gs "You must select a Branch")
    )
 
    if( branchop == "create" || branchop == "rename" then
@@ -3514,7 +3514,7 @@ procedure( CGBSbranchopCB(branchop)
 
       
       if( sf_bname_value == "" then
-         Error(gs "You must enter a branch name")
+         ErrorCG(gs "You must enter a branch name")
       )
 
       CheckFormat(gs sf_bname_value)
@@ -3662,7 +3662,7 @@ procedure( CGsetupSSHform()
       hiDisplayForm(cgsetupssh_form)
 
    else
-      Error(gs strcat("Could not open %s" sshKeyPath) )
+      ErrorCG(gs strcat("Could not open %s" sshKeyPath) )
    )
 
 )
@@ -3718,7 +3718,7 @@ procedure( CGpathBrowseFD(formMode)
    )
    retval=buildString(retval)
    retval=simplifyFilename(retval)
-   retval=Strip(GSstr(retval))
+   retval=StripCG(GSstr(retval))
    printf("%L\n" retval)
    cgpathbrowseform->sf_pathname->value = retval
 )
@@ -3735,7 +3735,7 @@ procedure( CGPBinitForm()
 
 procedure( CGPBinitFormCB()
 
-   gsinit_path = Strip(GSstr(cgpathbrowseform->sf_pathname->value))
+   gsinit_path = StripCG(GSstr(cgpathbrowseform->sf_pathname->value))
 
    gs = GitShell( ?path gsinit_path ?skipCheck t)
 
@@ -3745,7 +3745,7 @@ procedure( CGPBinitFormCB()
    if( gs->valid then
       Info(gs sprintf(nil "Git Repository Initialized in %s" gsinit_path))
    else
-      Error(gs sprintf(nil "Could not Initialize a Git Repository in %s\nCheck that you have permissions" gsinit_path))
+      ErrorCG(gs sprintf(nil "Could not Initialize a Git Repository in %s\nCheck that you have permissions" gsinit_path))
    )
 
 )
@@ -5299,7 +5299,7 @@ defmethod( ChangeState (( diff GMdiff ) )
       else
          if( diff->isDst? then
             ChangeChildrenState(diff)
-            Destroy(diff)
+            DestroyCG(diff)
          else
             Create(diff)
             ChangeChildrenState(diff)
@@ -5316,7 +5316,7 @@ defmethod( ChangeState (( diff GMdiff ) )
             ChangeChildrenState(diff)
          else
             ChangeChildrenState(diff)
-            Destroy(diff)
+            DestroyCG(diff)
          )
       )
    )
@@ -5663,7 +5663,7 @@ defmethod( GetParentObj (( inst GMobj) )
 
 )
 
-defmethod( Destroy (( inst GMobj )  )
+defmethod( DestroyCG (( inst GMobj )  )
 
    if( inst->isDst? then
       StoreAttrs(inst)

--- a/cdsgit-env/GitEnv/Check.ils
+++ b/cdsgit-env/GitEnv/Check.ils
@@ -16,8 +16,8 @@ defmethod( Check (( ge GitEnv ))
    ;Loop through each variable and check it's state
    foreach( envVar envVars
 
-      defaultValue = Get(ge envVar ?forcedPath ge->global_path)
-      setValue     = Get(ge envVar)
+      defaultValue = GetCG(ge envVar ?forcedPath ge->global_path)
+      setValue     = GetCG(ge envVar)
 
       if( defaultValue != setValue then
          mismatchString = strcat( mismatchString "\n" envVar " " setValue)

--- a/cdsgit-env/GitEnv/Get.ils
+++ b/cdsgit-env/GitEnv/Get.ils
@@ -9,19 +9,19 @@ defmethod( Get (( ge GitEnv ) varName @key (forcedPath nil))
    if(forcedPath then
       if( ge->verbose printf(strcat("GitEnv Git: Getting variable " varName " from forcedPath " forcedPath "\n")))
       envList = GetAll(ge forcedPath)
-      envVar = Search(ge varName)
+      envVar = SearchCG(ge varName)
    else
 
       ;See if the variable exists in the user's settings
       if( ge->verbose printf(strcat("GitEnv Git: Getting variable " varName " from " ge->user_path "\n")))
       envList = GetAll(ge ge->user_path)
-      varValue = Search(ge varName)
+      varValue = SearchCG(ge varName)
 
       ;If the variable was not found, load the default settings file
       if( !varValue then
          if( ge->verbose printf(strcat("GitEnv Git: Getting variable " varName " from " ge->global_path "\n")))
          envList = GetAll(ge ge->global_path)
-         envVar = Search(ge varName)
+         envVar = SearchCG(ge varName)
       )
    )
 

--- a/cdsgit-env/GitEnv/Get.ils
+++ b/cdsgit-env/GitEnv/Get.ils
@@ -1,6 +1,6 @@
 ;Get a variable from the settings. Will use default settings
 ;if the variable is not found in the user's settings file
-defmethod( Get (( ge GitEnv ) varName @key (forcedPath nil))
+defmethod( GetCG (( ge GitEnv ) varName @key (forcedPath nil))
 
    if( ge->verbose printf("========GitEnv Git============\n"))
 

--- a/cdsgit-env/GitEnv/GetAll.ils
+++ b/cdsgit-env/GitEnv/GetAll.ils
@@ -3,7 +3,7 @@ defmethod( GetAll (( ge GitEnv ) settingsPath)
 
    if( ge->verbose printf("GitEnv GetAll: Getting all variables from %s\n" settingsPath) )
 
-   envString = Open(ge settingsPath)
+   envString = OpenCG(ge settingsPath)
 
    ge->varList = Parse(ge envString)
 

--- a/cdsgit-env/GitEnv/Open.ils
+++ b/cdsgit-env/GitEnv/Open.ils
@@ -1,7 +1,7 @@
 ;Open the LCBU settings file
 ;Creates a file in ~ if it does not exist
 ;Returns a string containing all of the lines in the file
-defmethod( Open (( ge GitEnv ) settingsPath)
+defmethod( OpenCG (( ge GitEnv ) settingsPath)
 
    if( ge->verbose printf("GitEnv Open: Loading variables from File\n"))
 

--- a/cdsgit-env/GitEnv/Search.ils
+++ b/cdsgit-env/GitEnv/Search.ils
@@ -1,5 +1,5 @@
 ;Find a variable in a list of variables
-defmethod( Search (( ge GitEnv ) varName )
+defmethod( SearchCG (( ge GitEnv ) varName )
    returnVar = nil
    foreach(envVar ge->varList
 

--- a/cdsgit-env/GitEnv/Set.ils
+++ b/cdsgit-env/GitEnv/Set.ils
@@ -26,7 +26,7 @@ defmethod( Set (( ge GitEnv ) setName setValue )
 
    foutString = ""; Output string that will be written to file
 
-   envString = Open(ge ge->user_path)
+   envString = OpenCG(ge ge->user_path)
    strList = parseString(envString "\n")
 
    writeFile = nil

--- a/cdsgit-env/GitEnv/Set.ils
+++ b/cdsgit-env/GitEnv/Set.ils
@@ -1,10 +1,10 @@
-defmethod( Set (( ge GitEnv ) setName setValue )
+defmethod( SetCG (( ge GitEnv ) setName setValue )
 
    if( ge->verbose printf("========GitEnv Set============\n"))
 
    printf(strcat("GitEnv Set: Setting variable " setName " to " setValue " in " ge->user_path "\n"))
 
-   globalValue = Get(ge setName ?forcedPath ge->global_path)
+   globalValue = GetCG(ge setName ?forcedPath ge->global_path)
 
    ;Check that the name and values are legal
    line =  strcat(setName " = " setValue)

--- a/cdsgit-env/GitEnv/SetShell.ils
+++ b/cdsgit-env/GitEnv/SetShell.ils
@@ -9,7 +9,7 @@ defmethod( SetShell (( ge GitEnv ) varName @key (override t) )
    if( !shellResponse || override then
 
       if( ge->verbose printf(strcat("GitEnv SetShell: Setting Shell variable " varName " to " varName "\n")))
-      varValue = Get(ge varName)
+      varValue = GetCG(ge varName)
       setShellEnvVar(strcat(varName "=" varValue))
 
       shellResponse = getShellEnvVar(varName)

--- a/cdsgit-merge/classes/GMdiff/GMdiff.ils
+++ b/cdsgit-merge/classes/GMdiff/GMdiff.ils
@@ -143,7 +143,7 @@ defmethod( ChangeState (( diff GMdiff ) )
       else
          if( diff->isDst? then
             ChangeChildrenState(diff)
-            Destroy(diff)
+            DestroyCG(diff)
          else
             Create(diff)
             ChangeChildrenState(diff)
@@ -160,7 +160,7 @@ defmethod( ChangeState (( diff GMdiff ) )
             ChangeChildrenState(diff)
          else
             ChangeChildrenState(diff)
-            Destroy(diff)
+            DestroyCG(diff)
          )
       )
    )

--- a/cdsgit-merge/classes/GMdiff/GMobj.ils
+++ b/cdsgit-merge/classes/GMdiff/GMobj.ils
@@ -311,7 +311,7 @@ defmethod( GetParentObj (( inst GMobj) )
 
 )
 
-defmethod( Destroy (( inst GMobj )  )
+defmethod( DestroyCG (( inst GMobj )  )
 
    if( inst->isDst? then
       StoreAttrs(inst)

--- a/cdsgit-shell/GSpath.ils
+++ b/cdsgit-shell/GSpath.ils
@@ -27,14 +27,14 @@ procedure( GSpath(str @key (indexStatus nil) (treeStatus nil) (gs nil) )
       ?gs gs
    )
 
-   Type(newGsp)
+   TypeCG(newGsp)
 
    newGsp
 
 )
 
 ;Create a copy of a gsp object
-defmethod( Clone ((gsp GSpath) @key (str gsp->str) )
+defmethod( CloneCG ((gsp GSpath) @key (str gsp->str) )
 
    gsp_clone = GSpath( str
       ?indexStatus gsp->indexStatus
@@ -48,7 +48,7 @@ defmethod( Clone ((gsp GSpath) @key (str gsp->str) )
    gsp_clone->verbose   = gsp->verbose
    gsp_clone->depth     = gsp->depth
 
-   Type(gsp_clone)
+   TypeCG(gsp_clone)
 
    gsp_clone
 )

--- a/cdsgit-shell/GSpath/Convolve.ils
+++ b/cdsgit-shell/GSpath/Convolve.ils
@@ -25,14 +25,14 @@ let( (i)
 
    /* Modified, should always be full L and relative R
    ;Remove leading and trailing "/"
-   Strip(strL ?str_begin nil ?str_end t ?rexStr "/")
-   Strip(strR ?str_begin t ?str_end nil ?rexStr "/")
+   StripCG(strL ?str_begin nil ?str_end t ?rexStr "/")
+   StripCG(strR ?str_begin t ?str_end nil ?rexStr "/")
    */
 
    if(gsp->verbose printf("String Convolve\n\tstrL-%s\n\tstrR-%s\n" strL->str strR->str) )
 
-   lenL = Length(strL)
-   lenR = Length(strR)
+   lenL = LengthCG(strL)
+   lenR = LengthCG(strR)
 
 
    ;i represents an index of GSP where i=1 is the rightmost char

--- a/cdsgit-shell/GSpath/Depth.ils
+++ b/cdsgit-shell/GSpath/Depth.ils
@@ -4,7 +4,7 @@ defmethod( Depth (( gsp GSpath))
    depth = 0
    clast = ""
 
-   len = Length(gsp)
+   len = LengthCG(gsp)
 
    for( cindex 1 len
       c = GetChar(gsp cindex)

--- a/cdsgit-shell/GSpath/FullPath.ils
+++ b/cdsgit-shell/GSpath/FullPath.ils
@@ -6,6 +6,6 @@ defmethod( FullPath ((  gsp GSpath  ))
    )
 
    fullStr = strcat(gsp->gs->root->str "/" gsp->str)
-   fullGsp = Clone(gsp ?str fullStr)
+   fullGsp = CloneCG(gsp ?str fullStr)
    fullGsp
 )

--- a/cdsgit-shell/GSpath/IsInPath.ils
+++ b/cdsgit-shell/GSpath/IsInPath.ils
@@ -16,12 +16,12 @@ if( GetChar(gsp 1)!="/" || GetChar(ogsp 1) !="/" then
 )
 
 matched = nil
-if( Length(gsp) < Length(ogsp) then ;Path cannot be within the other if it is shorter
+if( LengthCG(gsp) < LengthCG(ogsp) then ;Path cannot be within the other if it is shorter
    matched = nil
 else
 
    matched = t
-   for(i 1 Length(ogsp)
+   for(i 1 LengthCG(ogsp)
 
       cho = GetChar(ogsp i)
       chi = GetChar(gsp i)

--- a/cdsgit-shell/GSpath/Subtract.ils
+++ b/cdsgit-shell/GSpath/Subtract.ils
@@ -4,7 +4,7 @@ defmethod( Subtract (( gsp GSpath ) gspS )
 if( GetChar(gsp 1)!="/" || GetChar(ogsp 1) !="/" then
    error("GSpath Subtract: Paths not be relative\nPath-%s OtherPath-%s" gsp->str gspS->str)
 )
-if( Length(gsp) < Length(gspS) then ;gsp must be longer than gspS
+if( LengthCG(gsp) < LengthCG(gspS) then ;gsp must be longer than gspS
    error("GSpath Subtract: Paths not be relative\nPath-%s OtherPath-%s" gsp->str gspS->str)
 )
 
@@ -12,8 +12,8 @@ if( !IsInPath(gsp gspS)
       error("GSpath Subtract: One path must be a subdirectory of the other\nPath-%s OtherPath-%s" gsp->str gspS->str)
 )
 
-if(  Length(gsp) > Length(gspS) then
-   tmpStr = substring( gsp->str Length(gspS)+1 )
+if(  LengthCG(gsp) > LengthCG(gspS) then
+   tmpStr = substring( gsp->str LengthCG(gspS)+1 )
 else
    tmpStr = ""
 )

--- a/cdsgit-shell/GSpath/Trim.ils
+++ b/cdsgit-shell/GSpath/Trim.ils
@@ -8,13 +8,13 @@ defmethod( Trim (( gsp GSpath ) @key (loop 1) (reverse t))
    ;If reverse = t - Remove tail (right) end of path
    ;Loop repeats
 
-   if(reverse Reverse(gsp) )
+   if(reverse ReverseCG(gsp) )
 
    for(i 1 loop
       resultStr = trimHelper(gsp)
    )
 
-   if(reverse Reverse(gsp) )
+   if(reverse ReverseCG(gsp) )
 
    gsp->str
 )
@@ -30,7 +30,7 @@ procedure( trimHelper(gsp)
 
    resultStr = ""
 
-   len = Length(gsp)
+   len = LengthCG(gsp)
 
    found = nil
 

--- a/cdsgit-shell/GSpath/Type.ils
+++ b/cdsgit-shell/GSpath/Type.ils
@@ -1,5 +1,5 @@
 ;Determing if the path is a file or directory
-defmethod( Type ((gsp GSpath))
+defmethod( TypeCG ((gsp GSpath))
 
       gsp->isDir  = isDir(gsp->str)
       gsp->isFile = isFile(gsp->str)

--- a/cdsgit-shell/GSstr.ils
+++ b/cdsgit-shell/GSstr.ils
@@ -13,10 +13,10 @@ procedure( GSstr(str)
 )
 
 ;Reverse a string
-defmethod( Reverse (( gss GSstr))
+defmethod( ReverseCG (( gss GSstr))
 
    resultStr=""
-   len = Length(gss)
+   len = LengthCG(gss)
 
    for(i 1 len
       resultStr = strcat(resultStr GetChar(gss len-(i-1)) )
@@ -27,7 +27,7 @@ defmethod( Reverse (( gss GSstr))
 )
 
 
-defmethod( Length (( gss GSstr))
+defmethod( LengthCG (( gss GSstr))
    len = strlen(gss->str)
    gss->length = len
    len
@@ -47,7 +47,7 @@ defmethod( GetChar (( gss GSstr) index @key (str nil) )
 )
 
 ;Remove whitespace from string
-defmethod( Strip (( gss GSstr ) @key (str_begin t) (str_end t) (rexStr " \t\n") )
+defmethod( StripCG (( gss GSstr ) @key (str_begin t) (str_end t) (rexStr " \t\n") )
 
    str = gss->str
 

--- a/cdsgit-shell/GitRepo.ils
+++ b/cdsgit-shell/GitRepo.ils
@@ -10,7 +10,7 @@ defclass( GitRepo
 procedure( GitRepo(gs)
 
    if( !gs->root then
-      Error(gs "No root directory found for git-shell")
+      ErrorCG(gs "No root directory found for git-shell")
    )
 
    gr = makeInstance( 'GitRepo ?root gs->root)

--- a/cdsgit-shell/GitShell/Add.ils
+++ b/cdsgit-shell/GitShell/Add.ils
@@ -1,11 +1,11 @@
-defmethod( Add (( gs GitShell ) oppath)
+defmethod( AddCG (( gs GitShell ) oppath)
 
    if( oppath && oppath != "" then
       syscmd = strcat("cd " gs->root->str " && git add --all -- " oppath)
       result=Cmd(gs syscmd)
 
       if(!result then
-         Error(gs sprintf(nil "Not a valid path %s\nCommand:%s" oppath syscmd))
+         ErrorCG(gs sprintf(nil "Not a valid path %s\nCommand:%s" oppath syscmd))
       )
    )
 

--- a/cdsgit-shell/GitShell/Branch.ils
+++ b/cdsgit-shell/GitShell/Branch.ils
@@ -17,7 +17,7 @@ defmethod( Branch (( gs GitShell ) @key (args "") (showCurrent t) )
    result=Cmd(gs syscmd)
 
    if(!result then
-      Error(gs sprintf(nil "Not a valid path %s\nCommand:%s" gs->root->str syscmd))
+      ErrorCG(gs sprintf(nil "Not a valid path %s\nCommand:%s" gs->root->str syscmd))
    else
 
       foreach(line parseString(result "\n")

--- a/cdsgit-shell/GitShell/Check.ils
+++ b/cdsgit-shell/GitShell/Check.ils
@@ -3,7 +3,7 @@
 defmethod( Check (( gs GitShell ))
 
    if( !isDir(gs->path) && gs->path != ""
-      Error(gs sprintf(nil "GitShell Check -- %L not a directory.\nSupport for files needs to be added" gs->path) )
+      ErrorCG(gs sprintf(nil "GitShell Check -- %L not a directory.\nSupport for files needs to be added" gs->path) )
    )
 
    syscmd = strcat("cd " gs->path " && git rev-parse --is-inside-work-tree ")
@@ -12,7 +12,7 @@ defmethod( Check (( gs GitShell ))
 
    if(result!="true\n" then
       gs->valid = nil
-      if( !gs->silent Error(gs sprintf(nil "Not a valid Git repository %s" gs->path)) )
+      if( !gs->silent ErrorCG(gs sprintf(nil "Not a valid Git repository %s" gs->path)) )
    else
       gs->valid = t
    )

--- a/cdsgit-shell/GitShell/CheckFormat.ils
+++ b/cdsgit-shell/GitShell/CheckFormat.ils
@@ -9,7 +9,7 @@ defmethod( CheckFormat (( gs GitShell ) refname)
       response = Cmd(gs strcat("git check-ref-format --branch \"" refname "\"") )
 
    else
-      Error(gs "GitShell CheckFormat: refname must be a string")
+      ErrorCG(gs "GitShell CheckFormat: refname must be a string")
    )
    response
 

--- a/cdsgit-shell/GitShell/Checkout.ils
+++ b/cdsgit-shell/GitShell/Checkout.ils
@@ -15,7 +15,7 @@ defmethod( Checkout (( gs GitShell ) gitSHA @key (oppath ".") (args nil) )
       if( gitSHA && gitSHA !="" then
          Cmd(gs strcat("cd " gs->path " && git checkout " gitSHA " -- " oppath) )
       else
-         Error(gs "GitShell Checkout: Must select a valid SHA")
+         ErrorCG(gs "GitShell Checkout: Must select a valid SHA")
       )
    )
    Refresh(gs)

--- a/cdsgit-shell/GitShell/CloneRepo.ils
+++ b/cdsgit-shell/GitShell/CloneRepo.ils
@@ -9,19 +9,19 @@ defmethod( CloneRepo (( gs GitShell ))
          result=Cmd(gs syscmd)
 
          if(!result then
-            Error(gs sprintf(nil "Not a valid url %s\nCommand:%s" gs->url syscmd))
+            ErrorCG(gs sprintf(nil "Not a valid url %s\nCommand:%s" gs->url syscmd))
          else
 
             badresult = car( parseString(result) ) == "fatal:"
 
             if(badresult then
-               Error(gs sprintf(nil "Clone Failed!\n URL\n  %s\nDestination\n  %s\nResponse\n  %s" gs->url gs->path response) )
+               ErrorCG(gs sprintf(nil "Clone Failed!\n URL\n  %s\nDestination\n  %s\nResponse\n  %s" gs->url gs->path response) )
             )
 
             Info(gs sprintf(nil "Clone Success!\n URL\n  %s\nDestination\n  %s" gs->url gs->path) )
          )
       else
-         Error(gs sprintf(nil "Please enter a URL to clone!\n %L" gs->url) )
+         ErrorCG(gs sprintf(nil "Please enter a URL to clone!\n %L" gs->url) )
       )
    )
 

--- a/cdsgit-shell/GitShell/Cmd.ils
+++ b/cdsgit-shell/GitShell/Cmd.ils
@@ -37,7 +37,7 @@ defmethod( Cmd (( gs GitShell ) sysCommand @key (ignoreFatal nil))
          responseParse = parseString(response "\n")
 
          if( pcreMatchp( "^fatal" car(responseParse)) || pcreMatchp( "^error" car(responseParse))  then
-            Error(gs sprintf(nil "Git command returned fatal:\n%s" response))
+            ErrorCG(gs sprintf(nil "Git command returned fatal:\n%s" response))
          )
       )
    )

--- a/cdsgit-shell/GitShell/Commit.ils
+++ b/cdsgit-shell/GitShell/Commit.ils
@@ -24,7 +24,7 @@ defmethod( Commit (( gs GitShell ) commit_log @key (merge nil) )
          result=Cmd(gs syscmd)
 
          if(!result then
-            Error(gs sprintf(nil "Not a valid path %s\nCommand:%s" gs->path syscmd))
+            ErrorCG(gs sprintf(nil "Not a valid path %s\nCommand:%s" gs->path syscmd))
          )
       )
    else

--- a/cdsgit-shell/GitShell/Depth.ils
+++ b/cdsgit-shell/GitShell/Depth.ils
@@ -17,7 +17,7 @@ defmethod( Depth (( gs GitShell ))
             gs->ideal_filter = 1
          )
          (t
-            Error(gs "Depth(gs) failed: dd->type is unknown!")
+            ErrorCG(gs "Depth(gs) failed: dd->type is unknown!")
          )
       )
    else

--- a/cdsgit-shell/GitShell/Error.ils
+++ b/cdsgit-shell/GitShell/Error.ils
@@ -1,7 +1,7 @@
 ;Return an error
 
 
-defmethod( Error (( gs GitShell ) errStr)
+defmethod( ErrorCG (( gs GitShell ) errStr)
 
 
    hiDisplayAppDBox(?name 'gitShellErrorForm

--- a/cdsgit-shell/GitShell/Export.ils
+++ b/cdsgit-shell/GitShell/Export.ils
@@ -14,7 +14,7 @@ defmethod( Export (( gs GitShell ) gitSHA)
 
    else
 
-      Error(gs "Must select a valid SHA")
+      ErrorCG(gs "Must select a valid SHA")
 
    )
 

--- a/cdsgit-shell/GitShell/Fetch.ils
+++ b/cdsgit-shell/GitShell/Fetch.ils
@@ -8,7 +8,7 @@ defmethod( Fetch (( gs GitShell ) @key (remote "origin") (args ""))
    result=Cmd(gs syscmd)
 
    if(!result then
-      Error(gs sprintf(nil "Fetch failed\nCommand:%s\nResponse%s" syscmd result))
+      ErrorCG(gs sprintf(nil "Fetch failed\nCommand:%s\nResponse%s" syscmd result))
    else
       if( result == "" then
          Info(gs "Fetch Complete (nothing to fetch)")

--- a/cdsgit-shell/GitShell/Init.ils
+++ b/cdsgit-shell/GitShell/Init.ils
@@ -6,7 +6,7 @@ Initialize a Git repository
 defmethod( Init (( gs GitShell ) @key (args "") )
 
    if( !gs->path || !isDir(gs->path) then
-      Error(gs sprintf(nil "GitShell Init: %L is not a directory" gs->path) )
+      ErrorCG(gs sprintf(nil "GitShell Init: %L is not a directory" gs->path) )
    )
 
    syscmd = strcat("cd " gs->path " && git init " args)

--- a/cdsgit-shell/GitShell/Log.ils
+++ b/cdsgit-shell/GitShell/Log.ils
@@ -11,7 +11,7 @@ let( (path)
    path = gs->path
 
    if( !branchname then
-      Error(gs "GitShell Log: branchname cannot be nil")
+      ErrorCG(gs "GitShell Log: branchname cannot be nil")
    )
 
    if(gs->verbose printf("LCBUgitRevs: Reading git log\n"))
@@ -21,7 +21,7 @@ let( (path)
    response = Cmd(gs gitLogCmd)
 
    if( response=="" || !response
-      Error(gs sprintf(nil "Path %s has an empty git log\nDo revisions of it exist in the repository?" gs->path))
+      ErrorCG(gs sprintf(nil "Path %s has an empty git log\nDo revisions of it exist in the repository?" gs->path))
    )
 
    lineList = parseString(response "\n")
@@ -39,7 +39,7 @@ let( (path)
 
             ;Pack up the last commit
             if(logCount > 0 then
-               gitLog = Strip(GSstr(gitLog))
+               gitLog = StripCG(GSstr(gitLog))
                revList = cons(list(gitCommit gitAuthor gitDate gitLog) revList)
             )
 

--- a/cdsgit-shell/GitShell/Merge.ils
+++ b/cdsgit-shell/GitShell/Merge.ils
@@ -10,7 +10,7 @@ defmethod( MergeCG (( gs GitShell ) merge_args)
       result=Cmd(gs syscmd)
 
       if(!result then
-         Error(gs sprintf(nil "Merge failed\nCommand:%s" syscmd))
+         ErrorCG(gs sprintf(nil "Merge failed\nCommand:%s" syscmd))
       )
    )
 
@@ -22,7 +22,7 @@ defmethod( MergeCG (( gs GitShell ) merge_args)
       cond(
          (rexMatchp("^warning" first_line) result = "warning")
          (rexMatchp("^error" first_line)
-            Error(gs sprintf(nil "Cannot Merge. Do you have modified files in your work tree?\n\n'git merge' returned:\n%s" result))
+            ErrorCG(gs sprintf(nil "Cannot Merge. Do you have modified files in your work tree?\n\n'git merge' returned:\n%s" result))
          )
          (t
             Refresh(gs)

--- a/cdsgit-shell/GitShell/Merge.ils
+++ b/cdsgit-shell/GitShell/Merge.ils
@@ -3,7 +3,7 @@
 */
 
 
-defmethod( Merge (( gs GitShell ) merge_args)
+defmethod( MergeCG (( gs GitShell ) merge_args)
 
    if( merge_args && merge_args != "" then
       syscmd = strcat("cd " gs->root->str " && git merge " merge_args)

--- a/cdsgit-shell/GitShell/Pull.ils
+++ b/cdsgit-shell/GitShell/Pull.ils
@@ -14,7 +14,7 @@ defmethod( Pull (( gs GitShell ) @key (remote "origin") (args "") (resolve t))
    result=Cmd(gs syscmd)
 
    if(!result then
-      Error(gs sprintf(nil "Pull failed\nCommand:%s\nResponse%s" syscmd result))
+      ErrorCG(gs sprintf(nil "Pull failed\nCommand:%s\nResponse%s" syscmd result))
    else
       Info(gs result)
    )
@@ -24,7 +24,7 @@ defmethod( Pull (( gs GitShell ) @key (remote "origin") (args "") (resolve t))
          gs->path = gs->root->str
          CGmergeResolveForm(gs)
       else
-         Error(gs "Pull failed due to unresolved conflicts")
+         ErrorCG(gs "Pull failed due to unresolved conflicts")
       )
    )
    Refresh(gs)

--- a/cdsgit-shell/GitShell/Push.ils
+++ b/cdsgit-shell/GitShell/Push.ils
@@ -11,7 +11,7 @@ defmethod( Push (( gs GitShell ) @key (remote "origin") (args ""))
    result=Cmd(gs syscmd)
 
    if(!result then
-      Error(gs sprintf(nil "Push failed\nCommand:%s\nResponse%s" syscmd result))
+      ErrorCG(gs sprintf(nil "Push failed\nCommand:%s\nResponse%s" syscmd result))
    else
       Info(gs result)
    )

--- a/cdsgit-shell/GitShell/Reset.ils
+++ b/cdsgit-shell/GitShell/Reset.ils
@@ -7,7 +7,7 @@ defmethod( Reset (( gs GitShell ) oppath)
       result=Cmd(gs syscmd)
 
       if(!reset then
-         Error(gs sprintf(nil "Not a valid path %s\nCommand:%s" oppath syscmd))
+         ErrorCG(gs sprintf(nil "Not a valid path %s\nCommand:%s" oppath syscmd))
       )
    )
    t

--- a/cdsgit-shell/GitShell/Root.ils
+++ b/cdsgit-shell/GitShell/Root.ils
@@ -5,10 +5,10 @@ defmethod( Root (( gs GitShell ))
    result=Cmd(gs syscmd)
 
    if(!result then
-      Error(gs sprintf(nil "Not a valid path %s\nCommand:%s" oppath syscmd))
+      ErrorCG(gs sprintf(nil "Not a valid path %s\nCommand:%s" oppath syscmd))
    else
       gss_result=GSpath(result)
-      Strip(gss_result)
+      StripCG(gss_result)
       gs->root = gss_result
    )
 

--- a/cdsgit-shell/GitShell/Status.ils
+++ b/cdsgit-shell/GitShell/Status.ils
@@ -19,7 +19,7 @@ defmethod( Status (( gs GitShell ) @key (showInfo t) )
    response = Cmd(gs status_cmd)
 
    if(!response then
-      Error(gs sprintf(nil "git status on path %s failed" gs->path))
+      ErrorCG(gs sprintf(nil "git status on path %s failed" gs->path))
    )
 
    if(response=="" then
@@ -80,7 +80,7 @@ let( (path)
    foreach( gsp gs->paths
 
       ;Filter the path
-      gsp_tmp = Clone(gsp)
+      gsp_tmp = CloneCG(gsp)
 
       trim_depth  = gs->filter - (3 - gsp_tmp->pathDepth)
 

--- a/forms/CGbranchSelect/CGBSbranchops.ils
+++ b/forms/CGbranchSelect/CGBSbranchops.ils
@@ -77,7 +77,7 @@ procedure( CGBSbranchopCB(branchop)
    parent_branch = nthelem(1 rf_branches_value)
 
    if( !rf_branches_value then
-      Error(gs "You must select a Branch")
+      ErrorCG(gs "You must select a Branch")
    )
 
    if( branchop == "create" || branchop == "rename" then
@@ -85,7 +85,7 @@ procedure( CGBSbranchopCB(branchop)
 
       ;Check the the branch name exists
       if( sf_bname_value == "" then
-         Error(gs "You must enter a branch name")
+         ErrorCG(gs "You must enter a branch name")
       )
 
       CheckFormat(gs sf_bname_value)

--- a/forms/CGbranchSelect/CGBSmerge.ils
+++ b/forms/CGbranchSelect/CGBSmerge.ils
@@ -34,7 +34,7 @@ procedure( CGBSmergeFormCB()
             gs->path = gs->root->str
             CGmergeResolveForm(gs)
          else
-            Error(gs "Merge failed due to unresolved conflicts")
+            ErrorCG(gs "Merge failed due to unresolved conflicts")
          )
       )
    )

--- a/forms/CGbranchSelect/CGBSmerge.ils
+++ b/forms/CGbranchSelect/CGBSmerge.ils
@@ -27,7 +27,7 @@ procedure( CGBSmergeFormCB()
    if(rf_branches_value then
       src_branch = nthelem(1 rf_branches_value)
       if( gs->verbose printf("CGBSmergeFormCB: Attempting to merge %L",src_branch))
-      result = Merge(gs src_branch)
+      result = MergeCG(gs src_branch)
       if( result == "warning" then
          response = Dialog(gs "Merge failed due to conflicts\nOpen the Merge confilt resolve form?")
          if(response then

--- a/forms/CGmergeResolve.ils
+++ b/forms/CGmergeResolve.ils
@@ -179,7 +179,7 @@ procedure( CGmergeResolveFormAddCB(option)
       oppath = nthelem(3 fchoice)
 
       Checkout(gs strcat("--" option) ?oppath oppath)
-      Add(gs oppath)
+      AddCG(gs oppath)
 
       case( option
          ("ours"   cgmergeresolve_form->rf_ours   = CGappendRFchoices(cgmergeresolve_form->rf_ours   fchoice) )

--- a/forms/CGpathBrowse/CGPBinit.ils
+++ b/forms/CGpathBrowse/CGPBinit.ils
@@ -14,7 +14,7 @@ procedure( CGPBinitForm()
 
 procedure( CGPBinitFormCB()
 
-   gsinit_path = Strip(GSstr(cgpathbrowseform->sf_pathname->value))
+   gsinit_path = StripCG(GSstr(cgpathbrowseform->sf_pathname->value))
 
    gs = GitShell( ?path gsinit_path ?skipCheck t)
 
@@ -24,7 +24,7 @@ procedure( CGPBinitFormCB()
    if( gs->valid then
       Info(gs sprintf(nil "Git Repository Initialized in %s" gsinit_path))
    else
-      Error(gs sprintf(nil "Could not Initialize a Git Repository in %s\nCheck that you have permissions" gsinit_path))
+      ErrorCG(gs sprintf(nil "Could not Initialize a Git Repository in %s\nCheck that you have permissions" gsinit_path))
    )
 
 )

--- a/forms/CGpathBrowse/CGpathBrowse.ils
+++ b/forms/CGpathBrowse/CGpathBrowse.ils
@@ -61,7 +61,7 @@ procedure( CGpathBrowseFD(formMode)
    )
    retval=buildString(retval)
    retval=simplifyFilename(retval)
-   retval=Strip(GSstr(retval)); Get rid of white space at the end
+   retval=StripCG(GSstr(retval)); Get rid of white space at the end
    printf("%L\n" retval)
    cgpathbrowseform->sf_pathname->value = retval
 )

--- a/forms/CGrevSelect/CGcheckout.il
+++ b/forms/CGrevSelect/CGcheckout.il
@@ -10,7 +10,7 @@ procedure( CGcheckoutForm(gs)
 
    Status(gs ?showInfo nil)
    if( gs->modified then
-      Error(gs "Cannot Checkout, you have uncommited modifications\n")
+      ErrorCG(gs "Cannot Checkout, you have uncommited modifications\n")
    )
 
    CGrevSelectForm(gs ?formTitle formTitle ?formCB formCB)
@@ -25,7 +25,7 @@ procedure( CGcheckoutFormCB()
    gs = cgrevselect_form->gs
 
    if( !gs->valid then
-      Error(gs "Object is not in a valid git repository")
+      ErrorCG(gs "Object is not in a valid git repository")
    )
 
    if(revSelected then
@@ -34,7 +34,7 @@ procedure( CGcheckoutFormCB()
 
       Status(gs ?showInfo nil)
       if( gs->modified then
-         Error(gs "Cannot Checkout, you have uncommited modifications\n")
+         ErrorCG(gs "Cannot Checkout, you have uncommited modifications\n")
       else
          Checkout(gs gitSHA)
          Reset(gs gs->path)

--- a/forms/CGrevSelect/CGexport.il
+++ b/forms/CGrevSelect/CGexport.il
@@ -20,7 +20,7 @@ procedure( CGexportFormCB()
    revSelected = CGgetRFchoices(cgrevselect_form->rf_revs)
 
    if( !gs->valid then
-      Error(gs "Object is not in a valid git repository")
+      ErrorCG(gs "Object is not in a valid git repository")
    )
 
    if(revSelected then

--- a/forms/CGsetupSSH.ils
+++ b/forms/CGsetupSSH.ils
@@ -59,7 +59,7 @@ procedure( CGsetupSSHform()
       hiDisplayForm(cgsetupssh_form)
 
    else
-      Error(gs strcat("Could not open %s" sshKeyPath) )
+      ErrorCG(gs strcat("Could not open %s" sshKeyPath) )
    )
 
 )

--- a/forms/CGstatus.ils
+++ b/forms/CGstatus.ils
@@ -175,7 +175,7 @@ procedure( CGstatusFormToggleCB()
          oppath = nthelem(3 fchoice)
 
          case(operation
-            ("add"     Add(gs oppath ) )
+            ("add"     AddCG(gs oppath ) )
             ("reset" Reset(gs oppath ) )
             (t error("invalied Toggle operation"))
          )

--- a/load_paths.il
+++ b/load_paths.il
@@ -1,25 +1,4 @@
 /*
    Setup paths for cdsgit
 */
-
-if( 'boundp('cdsgit_path_set) then
-
-   cdsgit_apps_dir = "/home/linear/git/lcbu-apps/"
-
-   orig_path = getShellEnvVar("PATH")
-
-
-   cdsgit_gui_command = "git-gui.sh"
-
-   git_path = strcat(cdsgit_apps_dir "/git/bin:")
-   git_gui_path = strcat(cdsgit_apps_dir "/git-gui:")
-   git_cola_path = strcat(cdsgit_apps_dir "/git-cola:")
-   tcl_path = strcat(cdsgit_apps_dir "/tcl/bin:")
-
-   new_path = strcat(git_path git_gui_path git_cola_path tcl_path orig_path)
-
-   setShellEnvVar("PATH" new_path)
-
-   cdsgit_path_set = t
-
-)
+cdsgit_gui_command = "git cola"

--- a/menus/cdsLibMgr.menu
+++ b/menus/cdsLibMgr.menu
@@ -29,7 +29,7 @@ lmgrCreateMenuItem("CGMseparator2"   "separator" '( ("callback" ("")) ) )
 lmgrCreateMenuItem("CGMseparator3"   "separator" '( ("callback" ("")) ) )
 lmgrCreateMenuItem("CGMseparator4"   "separator" '( ("callback" ("")) ) )
 
-lmgrCreateMenuItem("CGMgui"       "simple"  '( ("label" "Git-Gui")          ("callback" ("CGMlmgrCB")) ) )
+lmgrCreateMenuItem("CGMgui"       "simple"  '( ("label" "Git GUI")          ("callback" ("CGMlmgrCB")) ) )
 
 lmgrCreateMenuItem("CGMinit"      "simple"  '( ("label" "Init")               ("callback" ("CGMlmgrCB")) ) )
 lmgrCreateMenuItem("CGMstatusAll" "simple"  '( ("label" "List Repositories")  ("callback" ("CGMlmgrCB")) ) )

--- a/scripts/commands/CGmergeAbortCB.ils
+++ b/scripts/commands/CGmergeAbortCB.ils
@@ -3,7 +3,7 @@ procedure( CGmergeAbortCB(gs)
    response = Dialog(gs "Aborting Merge will cause all uncommitted changes to be lost!!\nProceed?")
 
    if( response then
-      Merge(gs "--abort")
+      MergeCG(gs "--abort")
    )
 
 )

--- a/scripts/libMgr/CGlmgrCB.il
+++ b/scripts/libMgr/CGlmgrCB.il
@@ -72,7 +72,7 @@ procedure( CGMlmgrCB(_menuName lib _c _v _f _cat)
       ("CGMcommit"        CGstatusForm(gs)   ); Currently Commit and status do the same thing
       ("CGMexport"        CGexportForm(gs)   )
       ("CGMcheckout"      CGcheckoutForm(gs) )
-      ("CGMadd"           Add(gs gs->path)   )
+      ("CGMadd"           AddCG(gs gs->path)   )
       ("CGMreset"         Reset(gs gs->path) )
       ("CGMdiscard"       Discard(gs)        )
       ;Merge
@@ -90,7 +90,7 @@ procedure( CGMlmgrCB(_menuName lib _c _v _f _cat)
       ;Diff
       ("CGMdiff"          GMergeGui() )
       ;Default
-      (t              Error( GitShell(?path "") strcat("Function " _menuName " has not been implemented yet!")  ) )
+      (t              ErrorCG( GitShell(?path "") strcat("Function " _menuName " has not been implemented yet!")  ) )
 
    )
 


### PR DESCRIPTION
cdsgit was redefining several functions that other tools were using. This was causing Pcell evaluation errors and other warnings.

My commits rename the cdsgit definition and use of those functions so that they do not clash.